### PR TITLE
What We Do: Adjusted Timeline and Cards

### DIFF
--- a/src/components/what-we-do/history/history-styles.js
+++ b/src/components/what-we-do/history/history-styles.js
@@ -22,9 +22,9 @@ const ImageContainer = styled.div`
     margin-left: -130px;
   }
   @media ${devices.tablet} {
-    margin-left: -100px;
+    margin-left: -90px;
   }
-  @media ${devices.tabletMax} {
+  @media (max-width: 450px) {
     overflow: hidden;
   }
   @media ${devices.laptop} {
@@ -47,7 +47,7 @@ const MobileImage = styled.img`
   @media ${devices.mobile} {
     transform: scale(1.25, 1.25);
     padding-top: 90px;
-    margin-bottom: 100px;
+    padding-bottom: 100px;
   }
   @media ${devices.tablet} {
     padding-top: 150px;

--- a/src/components/what-we-do/industry-bg/industry-bg-styles.js
+++ b/src/components/what-we-do/industry-bg/industry-bg-styles.js
@@ -6,7 +6,7 @@ import Img from "gatsby-image"
 const Container = styled.div`
   @media ${devices.mobile} {
     display: block;
-    padding: 8px ${padding.mobile};
+    padding: 0px ${padding.mobile} 8px;
     margin-bottom: 50px;
   }
   @media ${devices.tablet} {

--- a/src/components/what-we-do/programming-cards/programming-card-styles.js
+++ b/src/components/what-we-do/programming-cards/programming-card-styles.js
@@ -1,7 +1,7 @@
 import styled from "styled-components"
 import { H2 } from "../../../constants/typography"
 import { devices } from "../../../constants/devices"
-import { white, royalBlue } from "../../../constants/colors"
+import { white, royalBlue, navyBlue } from "../../../constants/colors"
 
 const CardContainer = styled.div`
   @media ${devices.mobile} {
@@ -32,10 +32,19 @@ const ImageContainer = styled.div`
   overflow: hidden;
 `
 
-const CardContent = styled.div`
+const CardContent = styled.div``
+
+const CardLink = styled.a`
+  display: block;
   color: ${white};
   background-color: ${royalBlue};
+  text-decoration: none;
+  transition: all 0.2s;
   flex: 1;
+  &:hover {
+    background-color: ${navyBlue};
+    cursor: pointer;
+  }
 `
 
 const CardTitle = styled(H2)`
@@ -69,6 +78,7 @@ export {
   CardContainer,
   ImageContainer,
   CardContent,
+  CardLink,
   CardTitle,
   CardTitleContainer,
   TextContainer,

--- a/src/components/what-we-do/programming-cards/programming-card-styles.js
+++ b/src/components/what-we-do/programming-cards/programming-card-styles.js
@@ -32,8 +32,6 @@ const ImageContainer = styled.div`
   overflow: hidden;
 `
 
-const CardContent = styled.div``
-
 const CardLink = styled.a`
   display: block;
   color: ${white};
@@ -77,7 +75,6 @@ const TextContainer = styled.div`
 export {
   CardContainer,
   ImageContainer,
-  CardContent,
   CardLink,
   CardTitle,
   CardTitleContainer,

--- a/src/components/what-we-do/programming-cards/programming-card.js
+++ b/src/components/what-we-do/programming-cards/programming-card.js
@@ -16,7 +16,7 @@ const ProgrammingCard = ({ title, description, photo, photoAlt, link }) => {
       <ImageContainer>
         <Img fluid={photo.fluid} alt={photoAlt} />
       </ImageContainer>
-      <CardLink href="/our-team" target="_blank" rel="noreferrer">
+      <CardLink href={link} target="_blank" rel="noreferrer">
         <div>
           <CardTitleContainer>
             <CardTitle>{title}</CardTitle>

--- a/src/components/what-we-do/programming-cards/programming-card.js
+++ b/src/components/what-we-do/programming-cards/programming-card.js
@@ -4,26 +4,28 @@ import { PCard } from "../../../constants/typography"
 import {
   CardContainer,
   ImageContainer,
-  CardContent,
+  CardLink,
   CardTitle,
   CardTitleContainer,
   TextContainer,
 } from "./programming-card-styles"
 
-const ProgrammingCard = ({ title, description, photo, photoAlt }) => {
+const ProgrammingCard = ({ title, description, photo, photoAlt, link }) => {
   return (
     <CardContainer>
       <ImageContainer>
         <Img fluid={photo.fluid} alt={photoAlt} />
       </ImageContainer>
-      <CardContent>
-        <CardTitleContainer>
-          <CardTitle>{title}</CardTitle>
-        </CardTitleContainer>
-        <TextContainer>
-          <PCard>{description}</PCard>
-        </TextContainer>
-      </CardContent>
+      <CardLink href="/our-team" target="_blank" rel="noreferrer">
+        <div>
+          <CardTitleContainer>
+            <CardTitle>{title}</CardTitle>
+          </CardTitleContainer>
+          <TextContainer>
+            <PCard>{description}</PCard>
+          </TextContainer>
+        </div>
+      </CardLink>
     </CardContainer>
   )
 }

--- a/src/constants/devices.js
+++ b/src/constants/devices.js
@@ -20,5 +20,5 @@ export const padding = {
   mobile: "28px",
   tablet: "45px",
   laptop: "80px",
-  desktop: "110px",
+  desktop: "155px",
 }

--- a/src/pages/what-we-do.js
+++ b/src/pages/what-we-do.js
@@ -42,6 +42,7 @@ const WhatWeDo = props => {
               description={card.shortDescription.shortDescription}
               photo={card.photo}
               photoAlt={card.photo.description}
+              link={card.link}
             />
           )
         })}

--- a/src/pages/what-we-do.js
+++ b/src/pages/what-we-do.js
@@ -104,6 +104,7 @@ export const pageQuery = graphql`
           }
           description
         }
+        link
       }
       platforms {
         title


### PR DESCRIPTION
- Fixed timeline cutoff on mobile and tablet devices (see photos below). Used `padding-bottom` instead of `margin-bottom`
- Made programming cards content a link and change color on hover (royal blue -> navy blue)
- Note: needed to make content div nested inside a block-level `<a>` tag in order for link to work
<img src="https://user-images.githubusercontent.com/60420625/115639173-f2378c00-a2e1-11eb-8c1a-3c0f046b1a38.jpg" alt="timelinebug" width="400"/>
<img src="https://user-images.githubusercontent.com/60420625/115639179-f4014f80-a2e1-11eb-9901-6302bed86902.jpg" alt="timefixed" width="400"/>
<img src="https://user-images.githubusercontent.com/60420625/115639198-ff547b00-a2e1-11eb-87c3-9dcc9bac3dfc.jpg" alt="hover"/>